### PR TITLE
Use new drupal composer url in documentation for creating a site profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Create a `composer.json` file in the profile's directory, for example:
     "repositories": [
         {
             "type": "composer",
-            "url": "https://packagist.drupal-composer.org"
+            "url": "https://packages.drupal.org/8"
         }
     ],
     "require": {
-        "drupal/metatag": "~8.0@dev"
+        "drupal/metatag": "~1.0@dev"
     }
 }
 ```


### PR DESCRIPTION
The `https://packagist.drupal-composer.org` url is deprecated. This updates the documentation for creating a site profile to use the official drupal composer repository url instead (which is already used in the main composer.json)

More info: https://www.drupal.org/node/2822344